### PR TITLE
Wrangle Travis for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ matrix:
   include:
     - { python: '3.6', env: TOXENV=py36-dj2.0 }
     - { python: '3.6', env: TOXENV=py36-dj2.1 }
-    - { python: '3.7', env: TOXENV=py37-dj2.0 }
-    - { python: '3.7', env: TOXENV=py37-dj2.1 }
+
+    # XXX (2018-08-10): Work around Travis shenanigans for Python 3.7:
+    # https://github.com/travis-ci/travis-ci/issues/9815
+    - { python: '3.7', env: TOXENV=py37-dj2.0, dist: xenial, sudo: true }
+    - { python: '3.7', env: TOXENV=py37-dj2.1, dist: xenial, sudo: true }
+
     # Codecov reporting:
     - { python: '3.6', env: TOXENV=py36-dj2.1-codecov }
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
 
     # Codecov reporting:
     - { python: '3.6', env: TOXENV=py36-dj2.1-codecov }
-  allow_failures:
-    - python: '3.7'  # Travis doesn't support Python 3.7 yet.
 
 install:
   - pip install tox


### PR DESCRIPTION
This adds the documented upstream Travis configuration workaround to make Python 3.7 work, for now.

(We can remove it later, once Travis supports 3.7 more properly.)