### PR TITLE
Renaming nav bar titles

### DIFF
--- a/src/buza/templates/base.html
+++ b/src/buza/templates/base.html
@@ -35,7 +35,7 @@
             </div>
             <div class="col">
                 {% if user.is_authenticated %}
-                    <a href="{% url 'user-detail' pk=user.pk %}" class="buza-nav__link">Account</a>
+                    <a href="{% url 'user-detail' pk=user.pk %}" class="buza-nav__link">Profile</a>
                 {% else %}
                     <a href="{% url 'login' %}" class="buza-nav__link">Sign in</a>
                 {% endif %}

--- a/src/buza/templates/base.html
+++ b/src/buza/templates/base.html
@@ -37,7 +37,7 @@
                 {% if user.is_authenticated %}
                     <a href="{% url 'user-detail' pk=user.pk %}" class="buza-nav__link">Profile</a>
                 {% else %}
-                    <a href="{% url 'login' %}" class="buza-nav__link">Sign in</a>
+                    <a href="{% url 'login' %}" class="buza-nav__link">Log in</a>
                 {% endif %}
             </div>
         </div>

--- a/src/buza/templates/buza/user_detail.html
+++ b/src/buza/templates/buza/user_detail.html
@@ -17,7 +17,7 @@
             <p>
                 <a class="btn btn-info btn-sm" href="{% url 'user-update' pk=user_object.pk %}">Edit Account</a>
                 <a class="btn btn-outline-info btn-sm" href="{% url 'password_change' %}">Change Password</a>
-                <a class="btn btn-outline-danger btn-sm" href="{% url 'logout' %}">Sign out</a>
+                <a class="btn btn-outline-danger btn-sm" href="{% url 'logout' %}">Log out</a>
             </p>
         {% endif %}
 


### PR DESCRIPTION
Users didn't really respond well to the current titles, they were not able to tell what account is, so using more common names will make things easier