### PR TITLE
add ordering for subjects

### DIFF
--- a/src/buza/templates/buza/subject_list.html
+++ b/src/buza/templates/buza/subject_list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load static buza_tags%}
+{% load static %}
+{% load buza_tags %}
 
 {% block head_extra %}
     {{ block.super }}

--- a/src/buza/templates/buza/subject_list.html
+++ b/src/buza/templates/buza/subject_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static buza_tags%}
 
 {% block head_extra %}
     {{ block.super }}
@@ -21,7 +21,8 @@
     </div>
 
 
-    {% for subject in subject_list %}
+    {% user_subjects_list user as subjects %}
+    {% for subject in subjects %}
         <div class="subject">
 
                 <a href="{% url 'subject-detail' subject.pk %}" class="d-block subject__title">

--- a/src/buza/templatetags/buza_tags.py
+++ b/src/buza/templatetags/buza_tags.py
@@ -9,3 +9,20 @@ register = template.Library()
 @register.simple_tag
 def topic_question_list(topic_name: str):
     return models.Question.objects.filter(topics__name__in=[topic_name])
+
+
+@register.simple_tag
+def user_subjects_list(user):
+    # chek if the user is logged in
+    # get all the subjects a user follows
+    subject_set = models.Subject.objects.all()
+    subjects = list(subject_set)
+
+    if user.is_anonymous or not user.subjects.all():
+        return subjects
+
+    for subject in subjects:
+        if subject in user.subjects.all():
+            subjects.remove(subject)
+            subjects = [subject] + subjects
+    return subjects


### PR DESCRIPTION
when a user joins/follows a subject they it will automatically move to the top of the subjects list. This will make navigation easier. Needs tests and it's super hacky