### PR TITLE
Settings: Remove unused buze_tags libraries declaration

### DIFF
--- a/src/buza/settings_base.py
+++ b/src/buza/settings_base.py
@@ -41,11 +41,6 @@ TEMPLATES = [{
             'django.contrib.auth.context_processors.auth',
             'django.contrib.messages.context_processors.messages',
         ],
-
-        'libraries': {
-            'buze_tags': 'buza.templatetags.buza_tags',
-
-        },
     },
 }]
 


### PR DESCRIPTION
Small follow-up to #31.