### PR TITLE
Order subjects followed first

### DIFF
--- a/src/buza/models.py
+++ b/src/buza/models.py
@@ -1,6 +1,7 @@
 from functools import partial
+from typing import Union
 
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -78,6 +79,10 @@ class User(AbstractUser):
 
     def __str__(self) -> str:
         return str(self.username)
+
+
+#: Helper type for Django request users: either anonymous or signed-in.
+RequestUser = Union[AnonymousUser, User]
 
 
 class Question(TimestampedModel, models.Model):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -543,10 +543,8 @@ class TestSubjectList(TestCase):
 
     def setUp(self) -> None:
         self.user: models.User = models.User.objects.create()
-        self.first_subject: models.Subject = \
-            models.Subject.objects.create(title="maths")
-        self.second_subject: models.Subject = \
-            models.Subject.objects.create(title="bio")
+        self.maths: models.Subject = models.Subject.objects.create(title='Maths')
+        self.biology: models.Subject = models.Subject.objects.create(title='Biology')
         self.path = reverse('subject-list')
 
     def test_get__unauthenticated(self) -> None:
@@ -558,13 +556,13 @@ class TestSubjectList(TestCase):
         assert HTTPStatus.OK == response.status_code
         self.assertNotContains(response, "Follow")
         self.assertNotContains(response, "Unfollow")
-        self.assertContains(response, self.first_subject.title, count=1)
-        self.assertContains(response, self.second_subject.title, count=1)
+        self.assertContains(response, self.maths.title, count=1)
+        self.assertContains(response, self.biology.title, count=1)
 
         # Listed by title.
         self.assertQuerysetEqual(response.context['subject_list'], [
-            '<Subject: bio>',
-            '<Subject: maths>',
+            '<Subject: Biology>',
+            '<Subject: Maths>',
         ])
 
     def test_get__no_followed_subjects(self) -> None:
@@ -576,13 +574,13 @@ class TestSubjectList(TestCase):
         assert HTTPStatus.OK == response.status_code
         self.assertContains(response, "follow")
         self.assertContains(response, "following", 0)
-        self.assertContains(response, self.first_subject.title, count=1)
-        self.assertContains(response, self.second_subject.title, count=1)
+        self.assertContains(response, self.maths.title, count=1)
+        self.assertContains(response, self.biology.title, count=1)
 
         # Listed by title.
         self.assertQuerysetEqual(response.context['subject_list'], [
-            '<Subject: bio>',
-            '<Subject: maths>',
+            '<Subject: Biology>',
+            '<Subject: Maths>',
         ])
 
     def test_get__followed_subjects(self) -> None:
@@ -591,19 +589,17 @@ class TestSubjectList(TestCase):
         :return:
         """
         self.client.force_login(self.user)
-        self.user.subjects.add(self.first_subject)
+        self.user.subjects.add(self.maths)
         response = self.client.get(self.path)
         self.assertTemplateUsed(response, 'buza/subject_list.html')
         assert HTTPStatus.OK == response.status_code
         self.assertContains(response, "following")
-        self.assertContains(
-            response,
-            "follow")
+        self.assertContains(response, "follow")
 
         # Maths (followed) listed first.
         self.assertQuerysetEqual(response.context['subject_list'], [
-            '<Subject: maths>',
-            '<Subject: bio>',
+            '<Subject: Maths>',
+            '<Subject: Biology>',
         ])
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -561,6 +561,12 @@ class TestSubjectList(TestCase):
         self.assertContains(response, self.first_subject.title, count=1)
         self.assertContains(response, self.second_subject.title, count=1)
 
+        # Listed by title.
+        self.assertQuerysetEqual(response.context['subject_list'], [
+            '<Subject: bio>',
+            '<Subject: maths>',
+        ])
+
     def test_get__no_followed_subjects(self) -> None:
         """
         Logged in users can view the list of questions and follow them
@@ -572,6 +578,12 @@ class TestSubjectList(TestCase):
         self.assertContains(response, "following", 0)
         self.assertContains(response, self.first_subject.title, count=1)
         self.assertContains(response, self.second_subject.title, count=1)
+
+        # Listed by title.
+        self.assertQuerysetEqual(response.context['subject_list'], [
+            '<Subject: bio>',
+            '<Subject: maths>',
+        ])
 
     def test_get__followed_subjects(self) -> None:
         """
@@ -587,6 +599,12 @@ class TestSubjectList(TestCase):
         self.assertContains(
             response,
             "follow")
+
+        # Maths (followed) listed first.
+        self.assertQuerysetEqual(response.context['subject_list'], [
+            '<Subject: maths>',
+            '<Subject: bio>',
+        ])
 
 
 class TestSubjectDetails(TestCase):


### PR DESCRIPTION
This changes the subject ordering so that subjects that the user is following appear grouped first. Subjects are then ordered by title.