### PR TITLE
Updating the question form UI to be much simpler

### DIFF
--- a/src/buza/templates/buza/question_form.html
+++ b/src/buza/templates/buza/question_form.html
@@ -14,6 +14,28 @@
 <div class="text-center mx-auto my-5" style="max-width: 40em">
 
     <h2>{% if question.pk %}Edit{% else %}Add a new{% endif %} Question</h2>
+    <form>
+  <div class="form-group">
+      <input type="text" class="form-control" placeholder="Write a new question...">
+  </div>
+        <div class="form-group">
+      <input type="text" class="form-control" placeholder="Topics in the question e.g. trignonometry, triangles, theta">
+  </div>
+         <div class="form-row">
+    <div class="form-group col-md-6">
+      <label for="inputSubject">Subject</label>
+      <select id="inputSubject" class="form-control">
+        <option>Mathematics</option>
+      </select>
+  </div>
+    <div class="form-group col-md-6">
+      <label for="inputGrade">Grade</label>
+      <select id="inputGrade" class="form-control">
+        <option>10</option>
+      </select>
+  </div>
+              </div>
+</form>
 
     {% crispy form %}
 


### PR DESCRIPTION
@pjdelport I started this PR because I wanted to improve the way we ask questions. At the moment the idea of a heading and a title are  a bit too confusing for some of the students. We have often assumed that they would be asking complex questions but the questions on the site http://edu-buza.herokuapp.com/questions/ show that the students aren't initially going to ask for complex questions. The questions style on Quora is much simpler and I think we should rather aim for that

- [x] Remove the question heading
- [ ] Restyle the question form