### PR TITLE
Improving the questions list view

### DIFF
--- a/src/buza/static/buza/css/questions.css
+++ b/src/buza/static/buza/css/questions.css
@@ -10,6 +10,7 @@
     /* Shadow */
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
     border-radius: 0.15em;
+    max-width: 40em;
 }
 .question__title {
     font-weight: bold;

--- a/src/buza/static/buza/css/questions.css
+++ b/src/buza/static/buza/css/questions.css
@@ -8,8 +8,8 @@
     margin-top: 1em;
     margin-bottom: 1em;
     /* Shadow */
-    border-radius: 0.25em;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    border-radius: 0.15em;
 }
 .question__title {
     font-weight: bold;

--- a/src/buza/static/buza/css/questions.css
+++ b/src/buza/static/buza/css/questions.css
@@ -8,8 +8,8 @@
     margin-top: 1em;
     margin-bottom: 1em;
     /* Shadow */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
     border-radius: 0.25em;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 .question__title {
     font-weight: bold;

--- a/src/buza/static/buza/css/questions.css
+++ b/src/buza/static/buza/css/questions.css
@@ -10,7 +10,7 @@
     /* Shadow */
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
     border-radius: 0.15em;
-    max-width: 40em;
+    max-width: 45em;
 }
 .question__title {
     font-weight: bold;

--- a/src/buza/static/buza/css/site.css
+++ b/src/buza/static/buza/css/site.css
@@ -1,7 +1,7 @@
 /* Site-wide Buza styles. */
 
 .bg-buza-site {
-    background-color: #F2F2F2;
+    background-color: #fafafa;
 }
 
 /* Block: Navigation bar. */

--- a/src/buza/static/buza/css/site.css
+++ b/src/buza/static/buza/css/site.css
@@ -1,7 +1,7 @@
 /* Site-wide Buza styles. */
 
 .bg-buza-site {
-    background-color: #fafafa;
+    background-color: #FAFAFA;
 }
 
 /* Block: Navigation bar. */

--- a/src/buza/templates/base.html
+++ b/src/buza/templates/base.html
@@ -16,7 +16,7 @@
 
     <title>{% block title %}Buza{% endblock %}</title>
 </head>
-
+<body class="bg-buza-site">
 <nav class="buza-nav">
     <div class="container">
 

--- a/src/buza/templates/buza/question_list.html
+++ b/src/buza/templates/buza/question_list.html
@@ -9,7 +9,7 @@
 {% block title %}Questions - {{ block.super }}{% endblock %}
 
 {% block content %}
-    <div class="mx-auto ml-5">
+    <div class="mx-auto ml-5 nav justify-content-end">
         <a href="{% url 'question-create' %}" class="d-block">
             <div class="btn btn-primary btn-buza-green">Ask New Question</div>
         </a>

--- a/src/buza/templates/buza/question_list.html
+++ b/src/buza/templates/buza/question_list.html
@@ -9,8 +9,7 @@
 {% block title %}Questions - {{ block.super }}{% endblock %}
 
 {% block content %}
-    <div class="d-flex flex-wrap justify-content-between align-items-baseline">
-        <h2>Questions</h2>
+    <div class="mx-auto ml-5">
         <a href="{% url 'question-create' %}" class="d-block">
             <div class="btn btn-primary btn-buza-green">Ask New Question</div>
         </a>

--- a/src/buza/templates/includes/question_card_brief.html
+++ b/src/buza/templates/includes/question_card_brief.html
@@ -5,7 +5,7 @@
 
     * question: The question being viewed
 {% endcomment %}
-<div class="question">
+<div class="question mx-auto">
     <a href="{% url 'question-detail' question.pk %}" class="d-block question__title">
         <p>{{ question.title }}</p>
     </a>


### PR DESCRIPTION
Some of the feedback we got from the user study is that the site's UI is not appealing (kids are so nice).
One of the things that stood out is that the questions are fairly large
I trying a quora approach where the questions are the center of the computer screen and the full width on mobile. 
This will give us room to provide a more features like adding the followed subject's list on the left and a possible `guide` on the right of the screen. See screen shots below